### PR TITLE
Return all supported endpoints as stub root request

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,9 @@ The solution requires:
 
 1. Run the application via Docker:
    ```
-   docker build -t trade-imports-data-api-stub .
-   docker run -p 8085:8085 trade-imports-data-api-stub
+   docker compose up
    ```
-2. Navigate to http://localhost:8085 and see:
-   ```
-   {"Status":"No matching mapping found"}
-   ```
+2. Navigate to http://localhost:8085 and see all endpoints supported
 
 ## Responses
 

--- a/src/Stub/WireMockExtensions.cs
+++ b/src/Stub/WireMockExtensions.cs
@@ -31,10 +31,10 @@ public static class WireMockExtensions
         }
     }
 
-    public static void StubUtilityEndpoints(this WireMockServer wireMock)
+    public static void StubAllEndpointsAvailable(this WireMockServer wireMock)
     {
         wireMock
-            .Given(Request.Create().WithPath("/utility/all-scenarios").UsingGet())
+            .Given(Request.Create().WithPath("/").UsingGet())
             .RespondWith(
                 Response
                     .Create()

--- a/src/Stub/WireMockHostedService.cs
+++ b/src/Stub/WireMockHostedService.cs
@@ -37,7 +37,7 @@ public class WireMockHostedService(
     private void ConfigureStubbedData()
     {
         _wireMockServer?.StubAllScenarios(logger);
-        _wireMockServer?.StubUtilityEndpoints();
+        _wireMockServer?.StubAllEndpointsAvailable();
     }
 
     public Task StopAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
As per PR title.

No point in an additional endpoint, just return supported endpoints as stub root request.